### PR TITLE
feat: add exports entry to package.json to make the component compatible with Vitest

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,5 +58,12 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist"
-  ]
+  ],
+  "exports": {
+    ".": {
+      "import": "./dist/vue3-zoomer.es.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./style.css": "./dist/style.css"
+  }
 }


### PR DESCRIPTION
# Why is this PR needed?
When trying to use this package inside my project I ran into an issue when testing my wrapper component with Vitest. The error displayed:

```
Error: Failed to resolve entry for package "vue3-zoomer". The package may have incorrect main/module/exports specified in its package.json.
    at packageEntryFailure (file:///project/node_modules/vite/dist/node/chunks/dep-DDxXL6bt.js:19549:15)
    at resolvePackageEntry (file:///project/node_modules/vite/dist/node/chunks/dep-DDxXL6bt.js:19546:3)
    at tryNodeResolve (file:///project/node_modules/vite/dist/node/chunks/dep-DDxXL6bt.js:19411:18)
    at ResolveIdContext.resolveId (file:///project/node_modules/vite/dist/node/chunks/dep-DDxXL6bt.js:19184:19)
    at EnvironmentPluginContainer.resolveId (file:///project/node_modules/vite/dist/node/chunks/dep-DDxXL6bt.js:47582:17)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async EventEmitter.onMessage (file:///project/node_modules/vitest/dist/chunks/index.68735LiX.js:91:20)
```

# What did I change?
I updated the package.json to include an explicit exports field. This resolves module resolution issues in environments like Vite and Vitest, which rely on the exports map to determine valid import paths.

Specifically, I added:

```
"exports": {
  ".": {
    "import": "./dist/vue3-zoomer.es.js",
    "types": "./dist/index.d.ts"
  },
  "./style.css": "./dist/style.css"
}
```

This ensures that:

- `import { ZoomImg } from 'vue3-zoomer` works reliably in ESM-based environments,
- Type definitions are correctly linked for TypeScript,
- And `import 'vue3-zoomer/style.css'` resolves without errors.


If you need any extra information or have any feedback, let me know ^^